### PR TITLE
Completely change html and make display looser

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -91,9 +91,11 @@ mod test {
             input: "50E2 - 0.3345E6",
             rule: Rule::expr,
             tokens: [
-                int(0, 4),
-                sub(5, 6),
-                float(7, 15),
+                expr(0, 15, [
+                    int(0, 4),
+                    sub(5, 6),
+                    float(7, 15),
+                ])
             ]
         };
     }
@@ -105,10 +107,10 @@ mod test {
             input: "(1 + 4)",
             rule: Rule::expr,
             tokens: [
-                paren(0, 7, [
+                expr(0, 7, [
                     int(1, 2),
                     add(3, 4),
-                    int(5, 6)
+                    int(5, 6),
                 ])
             ]
         };

--- a/static/console.css
+++ b/static/console.css
@@ -9,25 +9,42 @@ body {
     background-color: black;
 }
 
-section, ul {
+section {
     margin: 0;
-}
-
-input {
-    border: none;
-    font-size: 100%;
-    font-family: inherit;
-    color: inherit;
-    background-color: inherit;
-    margin: 0;
-    margin-left: 0.2rem;
-    width: calc(100% - 8em);
 }
 
 #console {
     list-style: none;
     margin-left: 0;
     word-wrap: break-word;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+}
+
+.line {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    width: 100%
+}
+
+p {
+    margin: 0;
+}
+
+.input {
+    flex-grow: 1;
+    min-width: 4em;
+    max-width: 100%;
+}
+
+.prompt {
+    color: lightgrey;
+    flex-grow: 0;
 }
 
 .error {
@@ -39,12 +56,22 @@ input {
     max-width: 40em;
 }
 
-.input:before {
-    content: "calc_rs > ";
-    color: gray;
+[contenteditable]:focus {
+    outline: 0px solid transparent;
 }
 
-p {
+pre {
     margin: 0;
-    padding: 0;
+    color: inherit;
+    font-size: inherit;
+    font-family: inherit;
+}
+
+a {
+    color: inherit;
+}
+
+a:hover {
+    background-color: white;
+    color: black;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -10,7 +10,8 @@
 
 <body>
     <section id="console">
-        <div class="entry input"><input type="text" id="latest"></div>
+        <div class="line" id="latest"><pre class="prompt">calc_rs > </pre><p contenteditable="true" class="input">about()</p></div>
+        <div class="line"><p class="info">This is the text about the thing.</p></div>
     </section>
     <script src="calc_rs.js"></script>
 </body>


### PR DESCRIPTION
The onus for displaying content is now in the `Object` enum, which can
construct its own DOM for each variant. The html was rethought to fix
some bugs.

Closes #3 and #2 and #4.